### PR TITLE
Shellchecks

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,15 +19,15 @@ Redi.sh is a primitive Redis client, written entirely in Bash. It allows you to 
 ##Example:
 
 ```shell
-$ declare Color="red"
-$ declare | grep ^Color= | ./redi.sh
+$ typeset Color="red"
+$ typeset | grep ^Color= | ./redi.sh
 $ ./redi.sh -g Color
 red
 ```
 
 ```shell
-$ declare -a Colors=([0]="red" [1]="green" [2]="blue")
-$ declare | grep ^Colors= | ./redi.sh -a
+$ typeset -a Colors=([0]="red" [1]="green" [2]="blue")
+$ typeset | grep ^Colors= | ./redi.sh -a
 $ ./redi.sh -ag Colors
 Colors=([0]="red" [1]="green" [2]="blue")
 ```

--- a/README.md
+++ b/README.md
@@ -6,25 +6,32 @@ Redi.sh is a primitive Redis client, written entirely in Bash. It allows you to 
 
 >By default redi.sh reads input from stdin and interprets it as a variable or array (if -a is used).
 
-> ./redi.sh [-a] [-g <variable|array>] [-p <password>] [-H <hostname>] [-P <port>]
+```
+./redi.sh [-a] [-g <variable|array>] [-p <password>] [-H <hostname>] [-P <port>]
 
     -a              : Tells the script that we are working with arrays, instead of regular variables.
     -g <name>       : Get the variable/array specified by <name> and output it to stdin.
     -p <password>   : Use "AUTH <password>" before running the SET/GET command to authenticate to redis.
     -H <hostname>   : Specify a custom hostname to connect to. Default is localhost.
     -P <port>       : Specify a custom port to connect to. Default is 6379.
+```
 
 ##Example:
-    $ typeset Color="red" 
-    $ typeset | grep ^Color= | ./redi.sh 
-    $ ./redi.sh -g Color 
-    red
-    $
-    $ typeset -a Colors=([0]="red" [1]="green" [2]="blue")
-    $ typeset | grep ^Colors= | ./redi.sh -a
-    $ ./redi.sh -ag Colors
-    Colors=([0]="red" [1]="green" [2]="blue")
-    
+
+```shell
+$ declare Color="red"
+$ declare | grep ^Color= | ./redi.sh
+$ ./redi.sh -g Color
+red
+```
+
+```shell
+$ declare -a Colors=([0]="red" [1]="green" [2]="blue")
+$ declare | grep ^Colors= | ./redi.sh -a
+$ ./redi.sh -ag Colors
+Colors=([0]="red" [1]="green" [2]="blue")
+```
+
 License
 ----
 

--- a/redi.sh
+++ b/redi.sh
@@ -25,7 +25,7 @@ function redis_read_bulk() {
         declare -i BYTE_COUNT=$1
 	declare -i FILE_DESC=$2
         if [[ $BYTE_COUNT -lt 0 ]]; then
-                echo 'ERROR: Null or incorrect string size returned.' >&2
+                echo ERROR: Null or incorrect string size returned. >&2
 		exec {FILE_DESC}>&-
                 exit 1
         fi
@@ -45,7 +45,8 @@ fi
 
 while read -r socket_data
 do
-        declare first_char=$(printf %b "$socket_data" | head -c1)
+        declare first_char
+        first_char=$(printf %b "$socket_data" | head -c1)
 
         case $first_char in
                 '+')
@@ -175,7 +176,7 @@ fi
 while read -r line
 do
         REDIS_TODO=$line
-done < /dev/stdin
+done </dev/stdin
 
 if [[ $REDIS_ARRAY -eq 1 ]]; then
 	ARRAY_NAME=$(printf %b "$REDIS_TODO" | cut -f1 -d=)

--- a/redi.sh
+++ b/redi.sh
@@ -70,8 +70,8 @@ do
 if [[ ! -z $PARAM_COUNT ]]; then
 	if [[ $PARAM_CUR -lt $PARAM_COUNT ]]; then
 		((PARAM_CUR+=1))
-		continue	
-	else	
+		continue
+	else
        		break
 	fi
 else
@@ -107,7 +107,7 @@ function redis_get_array() {
 function redis_set_array() {
 	typeset REDIS_ARRAY="$1"
 	typeset -a REDIS_ARRAY_VAL=("${!2}")
-	
+
 	printf %b "*2\r\n\$3\r\nDEL\r\n\$${#REDIS_ARRAY}\r\n$REDIS_ARRAY\r\n"
 	for i in "${REDIS_ARRAY_VAL[@]}"
 	do
@@ -141,7 +141,7 @@ while getopts g:P:H:p:ha opt; do
 			;;
 	esac
 done
-	
+
 
 exec {FD}<> /dev/tcp/"$REDIS_HOST"/"$REDIS_PORT"
 
@@ -158,12 +158,12 @@ if [[ ! -z $REDIS_GET ]]; then
 
 		for i in $(redis_read $FD)
 		do
-			OUTPUT_ARRAY+=($i)	
+			OUTPUT_ARRAY+=($i)
 		done
 
 		typeset | grep ^OUTPUT_ARRAY | sed "s/OUTPUT_ARRAY/$REDIS_GET/"
 
-	else	
+	else
 		redis_get_var "$REDIS_GET" >&$FD
 		redis_read $FD
 	fi

--- a/redi.sh
+++ b/redi.sh
@@ -6,24 +6,24 @@ CLIENT_VERSION=0.2
 
 
 function redis_read_str() {
-        declare REDIS_STR="$@"
+        typeset REDIS_STR="$@"
         printf %b "$REDIS_STR" | cut -f2- -d+ | tr -d '\r'
 }
 
 function redis_read_err() {
-        declare REDIS_ERR="$@"
+        typeset REDIS_ERR="$@"
         printf %s "$REDIS_ERR" | cut -f2- -d-
         exit 1
 }
 
 function redis_read_int() {
-        declare -i OUT_INT=$(printf %s "$1" | tr -d : | tr -d '\r')
+        typeset -i OUT_INT=$(printf %s "$1" | tr -d : | tr -d '\r')
         printf %b "$OUT_INT"
 }
 
 function redis_read_bulk() {
-        declare -i BYTE_COUNT=$1
-	declare -i FILE_DESC=$2
+        typeset -i BYTE_COUNT=$1
+        typeset -i FILE_DESC=$2
         if [[ $BYTE_COUNT -lt 0 ]]; then
                 echo ERROR: Null or incorrect string size returned. >&2
 		exec {FILE_DESC}>&-
@@ -36,16 +36,16 @@ function redis_read_bulk() {
 
 function redis_read() {
 
-declare -i FILE_DESC=$1
+typeset -i FILE_DESC=$1
 
 if [[ $# -eq  2 ]]; then
-	declare -i PARAM_COUNT=$2
-	declare -i PARAM_CUR=1
+	typeset -i PARAM_COUNT=$2
+	typeset -i PARAM_CUR=1
 fi
 
 while read -r socket_data
 do
-        declare first_char
+        typeset first_char
         first_char=$(printf %b "$socket_data" | head -c1)
 
         case $first_char in
@@ -84,30 +84,30 @@ done<&"$FILE_DESC"
 }
 
 function redis_compose_cmd() {
-    declare REDIS_PASS="$1"
+    typeset REDIS_PASS="$1"
     printf %b "*2\r\n\$4\r\nAUTH\r\n\$${#REDIS_PASS}\r\n$REDIS_PASS\r\n"
 }
 
 function redis_get_var() {
-	declare REDIS_VAR="$@"
+	typeset REDIS_VAR="$@"
 	printf %b "*2\r\n\$3\r\nGET\r\n\$${#REDIS_VAR}\r\n$REDIS_VAR\r\n"
 }
 
 function redis_set_var() {
-	declare REDIS_VAR="$1"
+	typeset REDIS_VAR="$1"
 	shift
-	declare REDIS_VAR_VAL="$@"
+	typeset REDIS_VAR_VAL="$@"
 	printf %b "*3\r\n\$3\r\nSET\r\n\$${#REDIS_VAR}\r\n$REDIS_VAR\r\n\$${#REDIS_VAR_VAL}\r\n$REDIS_VAR_VAL\r\n"
 }
 
 function redis_get_array() {
-	declare REDIS_ARRAY="$1"
+	typeset REDIS_ARRAY="$1"
 	printf %b "*4\r\n\$6\r\nLRANGE\r\n\$${#REDIS_ARRAY}\r\n$REDIS_ARRAY\r\n\$1\r\n0\r\n\$2\r\n-1\r\n"
 }
 
 function redis_set_array() {
-	declare REDIS_ARRAY="$1"
-	declare -a REDIS_ARRAY_VAL=("${!2}")
+	typeset REDIS_ARRAY="$1"
+	typeset -a REDIS_ARRAY_VAL=("${!2}")
 
 	printf %b "*2\r\n\$3\r\nDEL\r\n\$${#REDIS_ARRAY}\r\n$REDIS_ARRAY\r\n"
 	for i in "${REDIS_ARRAY_VAL[@]}"
@@ -155,14 +155,14 @@ if [[ ! -z $REDIS_GET ]]; then
 	if [[ $REDIS_ARRAY -eq 1 ]]; then
 		redis_get_array "$REDIS_GET" >&$FD
 		IFS=$'\n'
-		declare -a OUTPUT_ARRAY
+		typeset -a OUTPUT_ARRAY
 
 		for i in $(redis_read $FD)
 		do
 			OUTPUT_ARRAY+=($i)
 		done
 
-		declare | grep ^OUTPUT_ARRAY | sed s/OUTPUT_ARRAY/"$REDIS_GET"/
+		typeset | grep ^OUTPUT_ARRAY | sed s/OUTPUT_ARRAY/"$REDIS_GET"/
 
 	else
 		redis_get_var "$REDIS_GET" >&$FD
@@ -180,7 +180,7 @@ done </dev/stdin
 
 if [[ $REDIS_ARRAY -eq 1 ]]; then
 	ARRAY_NAME=$(printf %b "$REDIS_TODO" | cut -f1 -d=)
-	declare -a temparray=$(printf %b "$REDIS_TODO" | cut -f2- -d=)
+	typeset -a temparray=$(printf %b "$REDIS_TODO" | cut -f2- -d=)
 	redis_set_array "$ARRAY_NAME" temparray[@] >&$FD
 	redis_read $FD 1>/dev/null 2>&1
 	exit 0

--- a/redi.sh
+++ b/redi.sh
@@ -6,24 +6,24 @@ CLIENT_VERSION=0.2
 
 
 function redis_read_str() {
-        typeset REDIS_STR="$@"
+        declare REDIS_STR="$@"
         printf %b "$REDIS_STR" | cut -f2- -d"+" | tr -d '\r'
 }
 
 function redis_read_err() {
-        typeset REDIS_ERR="$@"
+        declare REDIS_ERR="$@"
         printf %s "$REDIS_ERR" | cut -f2- -d"-"
         exit 1
 }
 
 function redis_read_int() {
-        typeset -i OUT_INT=$(printf %s "$1" | tr -d '\:' | tr -d '\r')
+        declare -i OUT_INT=$(printf %s "$1" | tr -d '\:' | tr -d '\r')
         printf %b "$OUT_INT"
 }
 
 function redis_read_bulk() {
-        typeset -i BYTE_COUNT=$1
-	typeset -i FILE_DESC=$2
+        declare -i BYTE_COUNT=$1
+	declare -i FILE_DESC=$2
         if [[ $BYTE_COUNT -lt 0 ]]; then
                 echo "ERROR: Null or incorrect string size returned." >&2
 		exec {FILE_DESC}>&-
@@ -36,16 +36,16 @@ function redis_read_bulk() {
 
 function redis_read() {
 
-typeset -i FILE_DESC=$1
+declare -i FILE_DESC=$1
 
 if [[ $# -eq  2 ]]; then
-	typeset -i PARAM_COUNT=$2
-	typeset -i PARAM_CUR=1
+	declare -i PARAM_COUNT=$2
+	declare -i PARAM_CUR=1
 fi
 
 while read -r socket_data
 do
-        typeset first_char=$(printf %b "$socket_data" | head -c1)
+        declare first_char=$(printf %b "$socket_data" | head -c1)
 
         case $first_char in
                 "+")
@@ -83,30 +83,30 @@ done<&"$FILE_DESC"
 }
 
 function redis_compose_cmd() {
-    typeset REDIS_PASS="$1"
+    declare REDIS_PASS="$1"
     printf %b "*2\r\n\$4\r\nAUTH\r\n\$${#REDIS_PASS}\r\n$REDIS_PASS\r\n"
 }
 
 function redis_get_var() {
-	typeset REDIS_VAR="$@"
+	declare REDIS_VAR="$@"
 	printf %b "*2\r\n\$3\r\nGET\r\n\$${#REDIS_VAR}\r\n$REDIS_VAR\r\n"
 }
 
 function redis_set_var() {
-	typeset REDIS_VAR="$1"
+	declare REDIS_VAR="$1"
 	shift
-	typeset REDIS_VAR_VAL="$@"
+	declare REDIS_VAR_VAL="$@"
 	printf %b "*3\r\n\$3\r\nSET\r\n\$${#REDIS_VAR}\r\n$REDIS_VAR\r\n\$${#REDIS_VAR_VAL}\r\n$REDIS_VAR_VAL\r\n"
 }
 
 function redis_get_array() {
-	typeset REDIS_ARRAY="$1"
+	declare REDIS_ARRAY="$1"
 	printf %b "*4\r\n\$6\r\nLRANGE\r\n\$${#REDIS_ARRAY}\r\n$REDIS_ARRAY\r\n\$1\r\n0\r\n\$2\r\n-1\r\n"
 }
 
 function redis_set_array() {
-	typeset REDIS_ARRAY="$1"
-	typeset -a REDIS_ARRAY_VAL=("${!2}")
+	declare REDIS_ARRAY="$1"
+	declare -a REDIS_ARRAY_VAL=("${!2}")
 
 	printf %b "*2\r\n\$3\r\nDEL\r\n\$${#REDIS_ARRAY}\r\n$REDIS_ARRAY\r\n"
 	for i in "${REDIS_ARRAY_VAL[@]}"
@@ -154,14 +154,14 @@ if [[ ! -z $REDIS_GET ]]; then
 	if [[ $REDIS_ARRAY -eq 1 ]]; then
 		redis_get_array "$REDIS_GET" >&$FD
 		IFS=$'\n'
-		typeset -a OUTPUT_ARRAY
+		declare -a OUTPUT_ARRAY
 
 		for i in $(redis_read $FD)
 		do
 			OUTPUT_ARRAY+=($i)
 		done
 
-		typeset | grep ^OUTPUT_ARRAY | sed "s/OUTPUT_ARRAY/$REDIS_GET/"
+		declare | grep ^OUTPUT_ARRAY | sed "s/OUTPUT_ARRAY/$REDIS_GET/"
 
 	else
 		redis_get_var "$REDIS_GET" >&$FD
@@ -179,7 +179,7 @@ done < /dev/stdin
 
 if [[ $REDIS_ARRAY -eq 1 ]]; then
 	ARRAY_NAME=$(printf %b "$REDIS_TODO" | cut -f1 -d"=")
-	typeset -a temparray=$(printf %b "$REDIS_TODO" | cut -f2- -d"=")
+	declare -a temparray=$(printf %b "$REDIS_TODO" | cut -f2- -d"=")
 	redis_set_array "$ARRAY_NAME" temparray[@] >&$FD
 	redis_read $FD 1>/dev/null 2>&1
 	exit 0


### PR DESCRIPTION
There are more warnings still:

```
In redi.sh line 5:
CLIENT_VERSION=0.2
^-- SC2034: CLIENT_VERSION appears unused. Verify it or export it.


In redi.sh line 9:
        declare REDIS_STR="$@"
                          ^-- SC2124: Assigning an array to a string! Assign as array, or use * instead of @ to concatenate.


In redi.sh line 14:
        declare REDIS_ERR="$@"
                          ^-- SC2124: Assigning an array to a string! Assign as array, or use * instead of @ to concatenate.


In redi.sh line 20:
        declare -i OUT_INT=$(printf %s "$1" | tr -d : | tr -d '\r')
                   ^-- SC2155: Declare and assign separately to avoid masking return values.


In redi.sh line 92:
	declare REDIS_VAR="$@"
                          ^-- SC2124: Assigning an array to a string! Assign as array, or use * instead of @ to concatenate.


In redi.sh line 99:
	declare REDIS_VAR_VAL="$@"
                              ^-- SC2124: Assigning an array to a string! Assign as array, or use * instead of @ to concatenate.


In redi.sh line 183:
	declare -a temparray=$(printf %b "$REDIS_TODO" | cut -f2- -d=)
                   ^-- SC2034: temparray appears unused. Verify it or export it.
                   ^-- SC2155: Declare and assign separately to avoid masking return values.
```

although I am not sure how to deal with them.
Are you sure all uses of `declare` / `typeset` are necessary? Maybe some can be replaced by `local` or even removed…